### PR TITLE
Add character to the "made in" list for recipes that are hand-craftable

### DIFF
--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -1,6 +1,8 @@
 ---------------------------------------------------------------------------------------------------
 Version: 3.5.3
 Date: ????
+  Features:
+    - Added character to "made in" list for recipes that are hand-craftable (again)
   Bugfixes:
     - Fixed a crash when migrating from before version 3.0
 ---------------------------------------------------------------------------------------------------

--- a/src/scripts/database/crafter.lua
+++ b/src/scripts/database/crafter.lua
@@ -1,34 +1,7 @@
 local util = require("scripts.util")
 
 return function(database, metadata)
-  -- Characters as crafters
-  for name, prototype in pairs(global.prototypes.character) do
-    local ingredient_limit = prototype.ingredient_count
-    if ingredient_limit == 255 then
-      ingredient_limit = nil
-    end
-    database.entity[name] = {
-      accepted_modules = {}, -- Always empty
-      blueprintable = false,
-      can_burn = {}, -- Always empty
-      can_craft = {},
-      class = "entity",
-      crafting_speed = 1,
-      enabled = true,
-      entity_type = { class = "entity_type", name = prototype.type },
-      hidden = false,
-      ingredient_limit = ingredient_limit,
-      is_character = true,
-      placed_by = util.process_placed_by(prototype),
-      prototype_name = name,
-      recipe_categories_lookup = prototype.crafting_categories or {},
-      recipe_categories = util.convert_categories(prototype.crafting_categories or {}, "recipe_category"),
-      science_packs = {},
-      unlocked_by = {},
-    }
-    util.add_to_dictionary("entity", name, prototype.localised_name)
-    util.add_to_dictionary("entity_description", name, prototype.localised_description)
-  end
+  metadata.crafter_names = {}
 
   -- Actual crafters
   metadata.allowed_effects = {}
@@ -100,9 +73,40 @@ return function(database, metadata)
       size = util.get_size(prototype),
       unlocked_by = {},
     }
+    metadata.crafter_names[#metadata.crafter_names + 1] = name
     util.add_to_dictionary("entity", name, prototype.localised_name)
     util.add_to_dictionary("entity_description", name, prototype.localised_description)
   end
 
   metadata.rocket_silo_categories = rocket_silo_categories
+
+  -- Characters as crafters
+  for name, prototype in pairs(global.prototypes.character) do
+    local ingredient_limit = prototype.ingredient_count
+    if ingredient_limit == 255 then
+      ingredient_limit = nil
+    end
+    database.entity[name] = {
+      accepted_modules = {}, -- Always empty
+      blueprintable = false,
+      can_burn = {},         -- Always empty
+      can_craft = {},
+      class = "entity",
+      crafting_speed = 1,
+      enabled = true,
+      entity_type = { class = "entity_type", name = prototype.type },
+      hidden = false,
+      ingredient_limit = ingredient_limit,
+      is_character = true,
+      placed_by = util.process_placed_by(prototype),
+      prototype_name = name,
+      recipe_categories_lookup = prototype.crafting_categories or {},
+      recipe_categories = util.convert_categories(prototype.crafting_categories or {}, "recipe_category"),
+      science_packs = {},
+      unlocked_by = {},
+    }
+    metadata.crafter_names[#metadata.crafter_names + 1] = name
+    util.add_to_dictionary("entity", name, prototype.localised_name)
+    util.add_to_dictionary("entity_description", name, prototype.localised_description)
+  end
 end

--- a/src/scripts/database/recipe.lua
+++ b/src/scripts/database/recipe.lua
@@ -90,7 +90,7 @@ return function(database, metadata)
         num_item_ingredients = num_item_ingredients + 1
       end
     end
-    for crafter_name in pairs(global.prototypes.crafter) do
+    for _, crafter_name in ipairs(metadata.crafter_names) do
       local crafter_data = database.entity[crafter_name]
       local fluidbox_counts = metadata.crafter_fluidbox_counts[crafter_name] or { inputs = 0, outputs = 0 }
       if


### PR DESCRIPTION
This appears to be a former feature (9925b2a0845787fd997653d8507d2a72d42064df) that got lost along the way. Also shows the "can craft" section in the character entity info. Here's a screenshot of the mod with these changes applied.

**Screenshot**
![image](https://user-images.githubusercontent.com/114549/234714952-f9a27c8c-da88-4879-911c-367d11ffa6e6.png)
_A screenshot showing (from left-to-right): a non-hand-craftable recipe, a hand-craftable recipe, the character entity when clicked._