### PR TITLE
Improve entity.enabled_at_start and place_result for offshore pumps and labs

### DIFF
--- a/scripts/database.lua
+++ b/scripts/database.lua
@@ -62,10 +62,11 @@ function database.build()
   mining_drill(database)
 
   fluid(database, metadata)
-  item(database, metadata)
 
   lab(database)
-  offshore_pump(database)
+  offshore_pump(database)     -- requires fluids
+
+  item(database, metadata)    -- requires all entities
 
   recipe(database, metadata)
   resource(database)
@@ -75,6 +76,7 @@ function database.build()
   fluid.process_temperatures(database, metadata)
   mining_drill.add_resources(database)
   fuel_category.check_fake_category(database)
+  lab.process_researched_in(database)
 
   burning(database)
   entity_state(database)

--- a/scripts/database/lab.lua
+++ b/scripts/database/lab.lua
@@ -2,7 +2,10 @@ local table = require("__flib__.table")
 
 local util = require("scripts.util")
 
-return function(database)
+local lab_proc = {}
+
+-- store labs in science pack items' researched_in
+function lab_proc.process_researched_in(database)
   for name, prototype in pairs(global.prototypes.lab) do
     -- Add to items
     for _, item_name in ipairs(prototype.lab_inputs) do
@@ -11,7 +14,11 @@ return function(database)
         item_data.researched_in[#item_data.researched_in + 1] = { class = "entity", name = name }
       end
     end
+  end
+end
 
+function lab_proc.build(database)
+  for name, prototype in pairs(global.prototypes.lab) do
     local fuel_categories, fuel_filter = util.process_energy_source(prototype)
     database.entity[name] = {
       blueprintable = util.is_blueprintable(prototype),
@@ -39,3 +46,12 @@ return function(database)
     util.add_to_dictionary("entity_description", name, prototype.localised_description)
   end
 end
+
+-- When calling the module directly, call lab_proc.build
+setmetatable(lab_proc, {
+  __call = function(_, ...)
+    return lab_proc.build(...)
+  end,
+})
+
+return lab_proc

--- a/scripts/database/recipe.lua
+++ b/scripts/database/recipe.lua
@@ -63,8 +63,18 @@ return function(database, metadata)
         if io_type == "products" and (not disabled or disabled ~= 0) then
           local subtable = category_data[material.type .. "s"]
           subtable[#subtable + 1] = { class = material.type, name = material.name }
+
+          -- If this recipe is enabled at start and is not disabled,
+          -- set enabled at start for its products and their placement results.
           if enabled_at_start then
             material_data.enabled_at_start = true
+            for _, property in ipairs({ "place_result", "place_as_equipment_result" }) do
+              local placed_ident = material_data[property]
+              if placed_ident then
+                local placed_data = database[placed_ident.class][placed_ident.name]
+                placed_data.enabled_at_start = true
+              end
+            end
           end
         end
 


### PR DESCRIPTION
Set `enabled_at_start` for entities that are a placement result of a product of a recipe that is enabled at start.

Fix `place_result` of offshore pump items and lab items.